### PR TITLE
Adding example #Get functions

### DIFF
--- a/Functions/#Get.fmfn
+++ b/Functions/#Get.fmfn
@@ -1,0 +1,109 @@
+﻿/**
+ * =====================================
+ * #Get ( parameters ; name )
+ *
+ * PURPOSE:
+ * Retrieves values from a name-value pair list created with the
+ * # ( name ; value ) function. This function does not set any variables, making
+ * it non-destructive, in contrast with the #Assign functions, which may
+ * over-write the contents of variables.
+ *
+ * RETURNS:
+ * The value from the name-value pair specified by the name parameter. If such a
+ * value is not in the list, the function returns Null ("").
+ *
+ * PARAMETERS:
+ * parameters: The (potentially Null) string of name-value pairs.
+ * name: The name of the name-value pair from which to retrieve the value.
+ *
+ * EXAMPLES:
+ * #Get ( # ( "name1"; "value1" ) ; "name1" ) //= value1
+ * #Get ( # ( "name1"; "value1" ) ; "name2" ) //= Null
+ * #Get ( "This is not a valid name-value pair string" ; "name" ) //= Null
+ *
+ * DEPENDENCIES: none
+ *
+ * HISTORY:
+ * CREATED on 2011-01-14 by Jeremy Bante of The Support Group
+ * (jbante@supportgroup.com).
+ *
+ * REFERENCES:
+ * Script Parameter Interface Best Practice: http://filemakerstandards.org/pages/viewpage.action?pageId=557462
+ * =====================================
+ */
+
+Let ( [
+	~name = "¶$" & name & " = ";
+	~namePosition = Position ( "¶" & parameters ; ~name ; 1 ; 1	);
+	~valuePosition = ~namePosition + Length ( ~name ) - 1;
+	~endPosition = Position ( parameters ; ";¶" ; ~namePosition ; 1 );
+	~value =
+		Middle (
+			parameters;
+			~valuePosition;
+			~endPosition - ~valuePosition
+		);
+	~error = not ~namePosition or EvaluationError ( ~value )
+];
+	If ( ~error ; "" ; /*else*/ Evaluate ( ~value ) )
+)
+
+/*
+ * =====================================
+// Unit test
+Let ( [
+	~value1 = Random;
+	~test1 =
+		"#Get ( # ( \"name\" ; "
+		& ~value1
+		& " ) ; \"name\" )";
+	~evaluate1 = Evaluate ( ~test1 );
+	~result1 = If ( ~evaluate1 = ~value1 ; "Pass" ; "Fail" );
+
+	~value2 = Random;
+	~test2 =
+		"#Get ( # ( \"name\" ; "
+		& ~value2
+		& " ) ; \"differentName\" )";
+	~evaluate2 = Evaluate ( ~test2 );
+	~result2 = If ( IsEmpty ( ~evaluate2 ) ; "Pass" ; "Fail" );
+
+	~value3 = "This is not a valid name-value pair string";
+	~test3 =
+		"#Get ( "
+		& Quote ( ~value3 )
+		& " ; \"name\" )";
+	~evaluate3 = Evaluate ( ~test3 );
+	~result3 = If ( IsEmpty ( ~evaluate3 ) ; "Pass" ; "Fail" );
+
+	~value4 = "value 1";
+	~value5 = "value 2";
+	~test4 =
+		"#Get ( # ( \"name1\" ; "
+		& Quote ( ~value4 )
+		& " ) & # ( \"name2\" ; "
+		& Quote ( ~value5 )
+		& " ) ; \"name1\" )";
+	~evaluate4 = Evaluate ( ~test4 );
+	~result4 = If ( ~evaluate4 = ~value4 ; "Pass" ; "Fail" );
+
+	~test5 =
+		"#Get ( # ( \"name1\" ; "
+		& Quote ( ~value4 )
+		& " ) & # ( \"name2\" ; "
+		& Quote ( ~value5 )
+		& " ) ; \"name2\" )";
+	~evaluate5 = Evaluate ( ~test5 );
+	~result5 = If ( ~evaluate5 = ~value5 ; "Pass" ; "Fail" )
+
+];
+	List (
+		~test1 & " = " & ~evaluate1 & " // " & ~result1;
+		~test2 & " = " & ~evaluate2 & " // " & ~result2;
+		~test3 & " = " & ~evaluate3 & " // " & ~result3;
+		~test4 & " = " & ~evaluate4 & " // " & ~result4;
+		~test5 & " = " & ~evaluate5 & " // " & ~result5
+	)
+)
+ * =====================================
+ */

--- a/Functions/#GetScriptParameter.fmfn
+++ b/Functions/#GetScriptParameter.fmfn
@@ -1,0 +1,45 @@
+﻿/**
+ * =====================================
+ * #GetScriptParameter ( name )
+ *
+ * PURPOSE:
+ * Retrieves values from a name-value pair list created with the
+ * # ( name ; value ) function in the script parameter. This function does not
+ * set any variables, making it non-destructive, in contrast with the
+ * #AssignScriptParameters function, which can over-write variables. This
+ * function is equivalent to #Get ( Get ( ScriptParameter ) ; name ).
+ *
+ * RETURNS:
+ * The value from the name-value pair specified by the name parameter. If such a
+ * value is not in the script parameter, the function returns Null ("").
+ *
+ * PARAMETERS:
+ * name: The name of the name-value pair from which to retrieve the value.
+ *
+ * DEPENDENCIES: none
+ *
+ * HISTORY:
+ * CREATED on 2011-01-14 by Jeremy Bante of The Support Group
+ * (jbante@supportgroup.com).
+ *
+ * REFERENCES:
+ * Script Parameter Interface Best Practice: http://filemakerstandards.org/pages/viewpage.action?pageId=557462
+ * =====================================
+ */
+
+Let ( [
+	~name = "¶$" & name & " = ";
+	~parameters = Get ( ScriptParamter );
+	~namePosition = Position ( "¶" & ~parameters ; ~name ; 1 ; 1	);
+	~valuePosition = ~namePosition + Length ( ~name ) - 1;
+	~endPosition = Position ( ~parameters ; ";¶" ; ~namePosition ; 1 );
+	~value =
+		Middle (
+			~parameters;
+			~valuePosition;
+			~endPosition - ~valuePosition
+		);
+	~error = not ~namePosition or EvaluationError ( ~value )
+];
+	If ( ~error ; "" ; /*else*/ Evaluate ( ~value ) )
+)

--- a/Functions/#GetScriptResult.fmfn
+++ b/Functions/#GetScriptResult.fmfn
@@ -1,0 +1,45 @@
+﻿/**
+ * =====================================
+ * #GetScriptResult ( name )
+ *
+ * PURPOSE:
+ * Retrieves values from a name-value pair list created with the
+ * # ( name ; value ) function in the script result. This function does not
+ * set any variables, making it non-destructive, in contrast with the
+ * #AssignScriptResults function, which can over-write variables. This
+ * function is equivalent to #Get ( Get ( ScriptResult ) ; name ).
+ *
+ * RETURNS:
+ * The value from the name-value pair specified by the name parameter. If such a
+ * value is not in the script result, the function returns Null ("").
+ *
+ * PARAMETERS:
+ * name: The name of the name-value pair from which to retrieve the value.
+ *
+ * DEPENDENCIES: none
+ *
+ * HISTORY:
+ * CREATED on 2011-01-14 by Jeremy Bante of The Support Group
+ * (jbante@supportgroup.com).
+ *
+ * REFERENCES:
+ * Script Parameter Interface Best Practice: http://filemakerstandards.org/pages/viewpage.action?pageId=557462
+ * =====================================
+ */
+
+Let ( [
+	~name = "¶$" & name & " = ";
+	~parameters = Get ( ScriptResult );
+	~namePosition = Position ( "¶" & ~parameters ; ~name ; 1 ; 1	);
+	~valuePosition = ~namePosition + Length ( ~name ) - 1;
+	~endPosition = Position ( ~parameters ; ";¶" ; ~namePosition ; 1 );
+	~value =
+		Middle (
+			~parameters;
+			~valuePosition;
+			~endPosition - ~valuePosition
+		);
+	~error = not ~namePosition or EvaluationError ( ~value )
+];
+	If ( ~error ; "" ; /*else*/ Evaluate ( ~value ) )
+)


### PR DESCRIPTION
Adding example #Get functions for retrieving values from name-value pair strings without over-writing local variables. This came up in the script parameter handling discussions, and the possibility of #AssignScriptResults over-writing local variables has been bugging me ever since, even though I haven't personally run into the problem.
