### PR TITLE
Syntax typo fixes in #Assign and #Get functions

### DIFF
--- a/Functions/#Assign.fmfn
+++ b/Functions/#Assign.fmfn
@@ -44,7 +44,7 @@ Let (
         ~evaluateString =
                 "Let( [¶"
                 & parameters
-                & "$void = $void"&  //terminating variable to keep semicolon-delimited sytax in variableString consistent
+                & "$void = $void"  //terminating variable to keep semicolon-delimited sytax in variableString consistent
                 & "¶];¶"
                 & "True¶)";
  

--- a/Functions/#GetScriptParameter.fmfn
+++ b/Functions/#GetScriptParameter.fmfn
@@ -29,7 +29,7 @@
 
 Let ( [
 	~name = "¶$" & name & " = ";
-	~parameters = Get ( ScriptParamter );
+	~parameters = Get ( ScriptParameter );
 	~namePosition = Position ( "¶" & ~parameters ; ~name ; 1 ; 1	);
 	~valuePosition = ~namePosition + Length ( ~name ) - 1;
 	~endPosition = Position ( ~parameters ; ";¶" ; ~namePosition ; 1 );


### PR DESCRIPTION
Syntax typo fixes in #Assign and #Get functions
